### PR TITLE
docs: redesign README with modern concise layout

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,48 +1,36 @@
-# 🛍️ shopee-tiktokshops-lazada-api
+# shopee-tiktokshops-lazada-api
 
-[![npm version](https://badge.fury.io/js/shopee-tiktokshops-lazada-api.svg)](https://badge.fury.io/js/shopee-tiktokshops-lazada-api)
-[![License: ISC](https://img.shields.io/badge/License-ISC-blue.svg)](https://opensource.org/licenses/ISC)
-[![TypeScript](https://img.shields.io/badge/TypeScript-Ready-blue.svg)](https://www.typescriptlang.org/)
+<p align="center">
+  Unified TypeScript SDK for <b>Shopee</b>, <b>TikTok Shop</b>, and <b>Lazada</b> APIs.
+</p>
 
-A unified, strongly-typed Open API wrapper for **Shopee**, **TikTok Shop**, and **Lazada** built with TypeScript. Simplify e-commerce integrations and manage your multi-channel stores efficiently.
-
----
-
-## ✨ What's New in v4.1.0
-
-This update focuses on performance optimization, pagination bug fixes, and adding the latest data fields from Shopee Open API v2.
-
-### 🛒 Shopee Module Improvements
-- **Fix Data Shifting Bug:** Resolved a critical issue where orders could be duplicated or missed during pagination because the query time window shifted between loop iterations.
-- **`getOrders` Enhancements:**
-  - Optimized `page_size` to 100 (reducing HTTP requests by 50%).
-  - Added a 15-day time range validation as required by Shopee.
-- **`getOrderDetail` Enhancements:**
-  - Support for fetching multiple orders simultaneously by passing a `string[]`.
-  - Added the latest response fields: `return_request_due_date`, `edt`, `payment_info`, `international_label`.
-  - Added support for the `PENDING` order status (via `request_order_status_pending`).
-- **New Feature `getShipmentList`:** Added a dedicated API to retrieve orders ready for fulfillment (`READY_TO_SHIP`) or those requiring a retry (`RETRY_SHIP`).
-- **Enhanced Error Handling:** The system now explicitly catches Shopee API errors and returns detailed error messages instead of silently returning an empty result.
+<p align="center">
+  <a href="https://badge.fury.io/js/shopee-tiktokshops-lazada-api"><img src="https://badge.fury.io/js/shopee-tiktokshops-lazada-api.svg" alt="npm version" /></a>
+  <a href="https://opensource.org/licenses/ISC"><img src="https://img.shields.io/badge/License-ISC-blue.svg" alt="License ISC" /></a>
+  <a href="https://www.typescriptlang.org/"><img src="https://img.shields.io/badge/TypeScript-Ready-blue.svg" alt="TypeScript" /></a>
+</p>
 
 ---
 
-## ⚡️ Installation
+## Why this package?
 
-You can install the package via `npm` or `yarn`:
+- One consistent interface for 3 major marketplaces.
+- Strong TypeScript typings for safer integrations.
+- Production-focused methods for orders, products, shipping, and auth.
+
+## Install
 
 ```bash
-# Using npm
 npm install shopee-tiktokshops-lazada-api
-
-# Using yarn
+# or
 yarn add shopee-tiktokshops-lazada-api
 ```
 
-## 🚀 Usage
+## Quick Start
 
-### 🛒 Shopee Module
+### Shopee
 
-```typescript
+```ts
 import { ShopeeModule } from 'shopee-tiktokshops-lazada-api';
 
 const shopee = new ShopeeModule({
@@ -53,32 +41,9 @@ const shopee = new ShopeeModule({
 });
 ```
 
-**Supported Methods:**
+### TikTok Shop
 
-| Function                 | Status |
-| ------------------------ | ------ |
-| `getOrders`              | ✅ Done |
-| `getOrderDetail`         | ✅ Done |
-| `getShipmentList`        | ✅ Done |
-| `getProductItemList`     | ✅ Done |
-| `getProductItemBaseInfo` | ✅ Done |
-| `updateStock`            | ✅ Done |
-| `unListItem`             | ✅ Done |
-| `updatePrice`            | ✅ Done |
-| `addItem`                | ✅ Done |
-| `getChannelList`         | ✅ Done |
-| `fetchToken`             | ✅ Done |
-| `getCategory`            | ✅ Done |
-| `getAttributes`          | ✅ Done |
-| `getBrandList`           | ✅ Done |
-| `shippingParameter`      | ✅ Done |
-| `shipOrder`              | ✅ Done |
-
----
-
-### 🎵 TikTok Shop Module (v2 2309)
-
-```typescript
+```ts
 import { TiktokModule } from 'shopee-tiktokshops-lazada-api';
 
 const tiktok = new TiktokModule({
@@ -90,27 +55,9 @@ const tiktok = new TiktokModule({
 });
 ```
 
-**Supported Methods:**
+### Lazada
 
-| Function              | Status |
-| --------------------- | ------ |
-| `getOrderList`        | ✅ Done |
-| `getOrderDetail`      | ✅ Done |
-| `getProductDetail`    | ✅ Done |
-| `getAuthorizedShop`   | ✅ Done |
-| `getPackageTimeSlots` | ✅ Done |
-| `shipPackage`         | ✅ Done |
-| `getShippingDocument` | ✅ Done |
-| `getCategories`       | ✅ Done |
-| `getBrands`           | ✅ Done |
-| `getAttributes`       | ✅ Done |
-| `createProduct`       | ✅ Done |
-
----
-
-### 🛍 Lazada Module
-
-```typescript
+```ts
 import { LazadaModule } from 'shopee-tiktokshops-lazada-api';
 
 const lazada = new LazadaModule({
@@ -121,14 +68,25 @@ const lazada = new LazadaModule({
 });
 ```
 
+## Available Methods
+
+### Shopee
+
+`getOrders`, `getOrderDetail`, `getShipmentList`, `getProductItemList`, `getProductItemBaseInfo`, `updateStock`, `unListItem`, `updatePrice`, `addItem`, `getChannelList`, `fetchToken`, `getCategory`, `getAttributes`, `getBrandList`, `shippingParameter`, `shipOrder`
+
+### TikTok Shop
+
+`getOrderList`, `getOrderDetail`, `getProductDetail`, `getAuthorizedShop`, `getPackageTimeSlots`, `shipPackage`, `getShippingDocument`, `getCategories`, `getBrands`, `getAttributes`, `createProduct`
+
+### Lazada
+
+Core APIs for authorization, orders, and products are available via `LazadaModule`.
+
+## Contact
+
+- Email: **phamkhanhminhman97@gmail.com**
+- Skype: **phamkhanhminhman97@gmail.com**
+
 ---
 
-
-
-## 📬 Contact / Hỗ trợ
-
-- **Email:** phamkhanhminhman97@gmail.com
-- **Skype:** phamkhanhminhman97@gmail.com
-
----
-*Built with ❤️ for E-commerce Integrations. To be continued...*
+<p align="center"><i>Built for fast multi-channel commerce integrations.</i></p>


### PR DESCRIPTION
### Motivation
- Replace the existing verbose README (long changelog and large status tables) with a cleaner, modern and focused landing document to improve first-time onboarding.
- Make it faster for integrators to get started by surfacing only the value proposition, installation, copy-paste `Quick Start` snippets, and a compact API method reference.

### Description
- Rewrote `README.MD` to use a centered project intro and badges, a simplified `Install` section, concise `Quick Start` examples for Shopee/TikTok/Lazada, and a compact `Available Methods` grouping by marketplace.
- Removed lengthy changelog-style content, oversized status tables, and other verbose sections to keep the README minimal and actionable.
- Changes were committed under `26075fa` with the diff showing `1 file changed, 38 insertions(+), 80 deletions(-)`.

### Testing
- Executed `git add` and `git commit` which completed successfully and produced commit `26075fa`.
- Inspected the final `README.MD` with `nl -ba README.MD` which showed the updated content and layout correctly.
- Created the PR via `make_pr` which produced the PR body successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06d225d68883288ecfac35895f16bb)